### PR TITLE
Better Key Phrase Parsing

### DIFF
--- a/gadget/Cargo.toml
+++ b/gadget/Cargo.toml
@@ -13,6 +13,7 @@ subxt = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 backoff = { workspace = true }
 async-trait =  { workspace = true }
+regex = "1.10.2"
 
 # Eth2 Light Client
 eth2-to-substrate-relay = { path = "../eth2substrate-block-relay-rs" }

--- a/gadget/src/lib.rs
+++ b/gadget/src/lib.rs
@@ -198,7 +198,7 @@ pub fn parse_suri(suri: &str) -> Option<String> {
 	// If formatting has some hidden chars, new lines, extra spaces clean it up
 	let cleaned_suri = suri.replace("\"", "").replace("\n", "").trim().to_string();
 	// Regex to make sure we meet suri standards
-	let re = Regex::new(r"^(0x[0-9a-fA-F]{64})|([a-zA-Z]+(?:\s+[a-zA-Z]+)*)(/[\d'/]+)?(///\S+)?$").unwrap();
+	let re = Regex::new(r"^((0x)?[0-9a-fA-F]{64}|(\b\w+\b\s*){12,24})(/[\d'/]*(/[\d'/]+)*)?(///\S*)?$").unwrap();
 	re.captures(&cleaned_suri).map(|caps| {
         caps.iter()
             .skip(1) 

--- a/gadget/src/lib.rs
+++ b/gadget/src/lib.rs
@@ -6,9 +6,12 @@ use eth2_to_substrate_relay::eth2substrate_relay::Eth2SubstrateRelay;
 use lc_relay_config::RelayConfig;
 use lc_relayer_context::LightClientRelayerContext;
 use std::{path::PathBuf, sync::Arc};
+use subxt::ext::sp_core::crypto::{Ss58Codec, Ss58AddressFormat};
 use subxt::ext::sp_core::Pair;
+use subxt::utils::AccountId32;
 use tokio::signal::unix;
 use webb_proposals::TypedChainId;
+use regex::Regex;
 pub mod errors;
 
 /// Webb Relayer gadget initialization parameters.
@@ -36,10 +39,18 @@ pub async fn ignite_lc_relayer(ctx: LightClientRelayerContext) -> anyhow::Result
 		let api_client = Arc::new(api_client);
 		let pair = std::fs::read_to_string(&ctx.lc_init_config.path_to_signer_secret_key)
 			.expect("failed to read secret key");
+		let pair = parse_suri(&pair)
+			.expect("invalid key format");
 		let pair = subxt::ext::sp_core::sr25519::Pair::from_string(&pair, None);
 		let network = ctx.lc_relay_config.ethereum_network.as_typed_chain_id();
 		let mut eth_pallet = if let Ok(pair) = pair {
-			tracing::info!(target: "relay", "=== Initializing client with signer ===");
+			// Substrate default addr prefix
+			let pub_addr = pair.public().to_ss58check();
+			// GGX Prefix
+			let custom_prefix = Ss58AddressFormat::custom(8888);
+			//let acct_id = AccountId32::from(pair.public());
+            let ggx_addr = pair.public().to_ss58check_with_version(custom_prefix);
+			tracing::info!(target: "relay", "Initializing client with signer: pub_addr = {}, ggx_addr = {}", pub_addr, ggx_addr);
 			EthClientPallet::new_with_pair(api_client, pair, network)
 		} else {
 			tracing::info!(target: "relay", "=== Initializing client without signer. Alice used as default ===");
@@ -145,4 +156,17 @@ fn loads_light_client_pallet_init_config(
 	config_path: &PathBuf,
 ) -> anyhow::Result<eth2_pallet_init::config::Config> {
 	Ok(eth2_pallet_init::config::Config::load_from_toml(config_path.clone()))
+}
+
+pub fn parse_suri(suri: &str) -> Option<String> {
+	// If formatting has some hidden chars, new lines, extra spaces clean it up
+	let cleaned_suri = suri.replace("\"", "").replace("\n", "").trim().to_string();
+	// Regex to make sure we meet suri standards
+	let re = Regex::new(r"^(0x[0-9a-fA-F]{64})|([a-zA-Z]+(?:\s+[a-zA-Z]+)*)(/[\d'/]+)?(///\S+)?$").unwrap();
+	re.captures(&cleaned_suri).map(|caps| {
+        caps.iter()
+            .skip(1) 
+            .filter_map(|m| m.map(|m| m.as_str().trim())) // Convert matches to strings, trim them
+            .collect::<String>() // Concatenate all valid groups into a single String
+    })
 }


### PR DESCRIPTION
## Summary of changes
- Converts config path to a `Path` for checking for permissions, file/path existence, and empty file
- New function `parse_suri` for using regex to make sure the file is in proper format and cleans it up from most whitespace issues, newlines that may be mistakenly entered
- Handles 0x prefixed keys and `/` soft junction, `//` hard junction, and `///` password, 12-24 words
- Logging for each issue of, invalid key format, no key found, bad permissions, empty contents, and failing to read it
- Logging of what address is being used for the user to know what to fund

Notes: Everything is set as `info` in the logs for now, we can discuss what fits better for any, but as the flow is currently these will just tell the user and continue forward to use Alice but user will then understand why.

### Reference issue to close
- Closes 250

-----
### Code Checklist 

- [x ] Tested
- [ ] Documented
